### PR TITLE
print errors. fix status

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -22,14 +22,14 @@ const repositoryDetails = ( input_repo ) => {
 
 const repositoryClone = async( git_url, local_path, branch, auto_create_branch ) => {
 	const common_arg = '--quiet --no-hardlinks --no-tags';
-	const options    = { silent: true };
-	let stauts       = true;
+	const options    = { silent: false };
+	let status       = true;
 	if( 'default' === branch ) {
 		await exec.exec( `git clone ${common_arg} --depth 1 ${git_url} "${local_path}"`, [], options )
 				  .then( () => toolkit.log.success( 'Repository Cloned', '	' ) )
 				  .catch( () => {
-					  toolkit.log.error( 'Repository Dose Not Exists !', '	' );
-					  stauts = false;
+					  toolkit.log.error( 'Unable to Clone Repository!', '	' );
+					  status = false;
 				  } );
 	} else {
 		await exec.exec( `git clone ${common_arg} --depth 1 --branch "${branch}" ${git_url} "${local_path}"`, [], options )
@@ -43,24 +43,24 @@ const repositoryClone = async( git_url, local_path, branch, auto_create_branch )
 													 .then( () => {
 														 toolkit.log.success( 'Repository Cloned', '	' );
 														 toolkit.log.success( 'Branch Created', '	' );
-														 stauts = 'created';
+														 status = 'created';
 													 } )
 													 .catch( () => {
 														 toolkit.log.error( 'Unable To Create Branch.', '	' );
-														 stauts = false;
+														 status = false;
 													 } );
 									} )
 									.catch( () => {
 										toolkit.log.error( 'Repository Dose Not Exists !', '	' );
-										stauts = false;
+										status = false;
 									} );
 					  } else {
 						  toolkit.log.error( `Repository Branch ${branch} Not Found!`, '	' );
-						  stauts = false;
+						  status = false;
 					  }
 				  } );
 	}
-	return stauts;
+	return status;
 };
 
 const extract_workflow_file_info = ( file ) => {


### PR DESCRIPTION
/link #9 

In my case, it's not that the repo doesn't exist, but rather that git clone fails for some other reason. for example:

```
Run FATMAP/action-github-workflow-sync@main
-------------------------------------------------------
⚙️ Basic Config
  * AUTO_CREATE_NEW_BRANCH     : false
  * COMMIT_EACH_FILE           : true
  * PULL_REQUEST               : true
  * DRY_RUN                    : true
  * WORKFLOW_FILES_DIR         : workflows
  * WORKSPACE                  : /home/runner/work/workflow-sync/
  * SKIP_CI                    : false
  * COMMIT_MESSAGE             : false
-------------------------------------------------------

📓 FATMAP/search-infra

0s
Run FATMAP/action-github-workflow-sync@main
-------------------------------------------------------
⚙️ Basic Config
  * AUTO_CREATE_NEW_BRANCH     : false
  * COMMIT_EACH_FILE           : true
  * PULL_REQUEST               : true
  * DRY_RUN                    : true
  * WORKFLOW_FILES_DIR         : workflows
  * WORKSPACE                  : /home/runner/work/workflow-sync/
  * SKIP_CI                    : false
  * COMMIT_MESSAGE             : false
-------------------------------------------------------

📓 FATMAP/search-infra
  ⚙️ Repository Config
  	Slug        : search-infra
  	Owner       : FATMAP
  	Git URL     : ***github.com/FATMAP/search-infra.git
  	Branch      : default
  	Local Path  : /home/runner/work/workflow-sync/FATMAP/search-infra/default/
  /usr/bin/git clone --quiet --no-hardlinks --no-tags --depth 1 ***github.com/FATMAP/search-infra.git /home/runner/work/workflow-sync/FATMAP/search-infra/default/
  fatal: destination path '/home/runner/work/workflow-sync/FATMAP/search-infra/default' already exists and is not an empty directory.
  Error: 	🛑️  Unable to Clone Repository!
```

- fix typo `status`
- don't be `silent` when execing
- update error message on clone fails