### PR TITLE
Add git url variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This also isn't limited to Github Action yaml files - another use case could be 
 | **Argument** | Defaults | Description |
 | --- | :---: | :---: | 
 | `GITHUB_TOKEN` | - | **Required** Token to use to get repos and write secrets. `${{secrets.GITHUB_TOKEN}}` will not work. instead **Personal Access Token Required*** |
+| `GIT_URL` | github.com | URL for the instance of github, where repositories should be searched for. Change if using a GHES instance. |
 | `REPOSITORIES` | - | **Required** New line deliminated regex expressions to select repositories. Repositires are limited to those in whcich the token user is an owner or collaborator. |
 | `WORKFLOW_FILES` | - | **Required** New line deliminated regex expressions. workflow files to be copied to provided repositores |
 | `DRY_RUN` | ***false*** | Run everything except for nothing will be pushed. |

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
   GITHUB_TOKEN:
     description: "Token to use to get repos and write secrets"
     required: true
+  GIT_URL:
+    description: "The URL to the Github server. Defaults to github.com. Change if using a GHES instance."
+    default: 'github.com'
+    required: false
   DRY_RUN:
     description: "Run everything except for nothing will be Updated."
     required: false

--- a/src/helper.js
+++ b/src/helper.js
@@ -3,6 +3,7 @@ const toolkit = require( 'actions-js-toolkit' );
 
 const repositoryDetails = ( input_repo ) => {
 	let GIT_TOKEN = require( './variables' ).GITHUB_TOKEN;
+	let GIT_URL   = require( './variables' ).GIT_URL;
 	let WORKSPACE = require( './variables' ).WORKSPACE;
 	input_repo    = input_repo.split( '@' );
 
@@ -14,7 +15,7 @@ const repositoryDetails = ( input_repo ) => {
 	return {
 		owner: input_repo[ 0 ],
 		repository: input_repo[ 1 ],
-		git_url: `https://x-access-token:${GIT_TOKEN}@github.com/${input_repo[ 0 ]}/${input_repo[ 1 ]}.git`,
+		git_url: `https://x-access-token:${GIT_TOKEN}@${GIT_URL}/${input_repo[ 0 ]}/${input_repo[ 1 ]}.git`,
 		branch,
 		local_path: `${WORKSPACE}${input_repo[ 0 ]}/${input_repo[ 1 ]}/${branch}/`
 	};

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ async function run() {
 	let COMMIT_EACH_FILE       = require( './variables' ).COMMIT_EACH_FILE;
 	let DRY_RUN                = require( './variables' ).DRY_RUN;
 	let GITHUB_TOKEN           = require( './variables' ).GITHUB_TOKEN;
+	let GIT_URL                = require( './variables' ).GIT_URL;
 	let WORKFLOW_FILES_DIR     = require( './variables' ).WORKFLOW_FILES_DIR;
 	let WORKSPACE              = require( './variables' ).WORKSPACE;
 	let REPOSITORIES           = require( './variables' ).REPOSITORIES;

--- a/src/variables.js
+++ b/src/variables.js
@@ -7,6 +7,7 @@ const DRY_RUN                = toolkit.input.tobool( core.getInput( 'DRY_RUN' ) 
 const PULL_REQUEST           = toolkit.input.tobool( core.getInput( 'PULL_REQUEST' ) );
 const SKIP_CI                = toolkit.input.tobool( core.getInput( 'SKIP_CI' ) );
 const GITHUB_TOKEN           = core.getInput( 'GITHUB_TOKEN' );
+const GIT_URL                = core.getInput( 'GIT_URL' );
 const RAW_REPOSITORIES       = core.getInput( 'REPOSITORIES' );
 const COMMIT_MESSAGE         = core.getInput( 'COMMIT_MESSAGE' );
 const RAW_WORKFLOW_FILES     = core.getInput( 'WORKFLOW_FILES' );
@@ -23,6 +24,7 @@ module.exports = {
 	COMMIT_EACH_FILE,
 	DRY_RUN,
 	GITHUB_TOKEN,
+	GIT_URL,
 	RAW_REPOSITORIES,
 	PULL_REQUEST,
 	RAW_WORKFLOW_FILES,


### PR DESCRIPTION
This creates a GIT_URL variable, which allows those using Github Enterprise to utilize this Action.
* Added GIT_URL 
* Updated repository lookup url to use GIT_URL
* Created Input parameter in Action for GIT_URL; defaults to 'github.com'
* Updated README.md to indicate GIT_URL is an option